### PR TITLE
[✨ Feature] 댓글 상세 페이지 수정 및 삭제 로직 적용

### DIFF
--- a/src/components/comment-detail/CommentDetail.styled.tsx
+++ b/src/components/comment-detail/CommentDetail.styled.tsx
@@ -68,7 +68,6 @@ export const CommentSection = styled.div<{ readonly: boolean }>`
     ${({ readonly }) =>
       readonly &&
       `
-    height: auto;
     background-color: var(--color-black);
 
     &:focus {

--- a/src/components/comment-detail/CommentEditButton.tsx
+++ b/src/components/comment-detail/CommentEditButton.tsx
@@ -1,0 +1,63 @@
+import { Button } from '../common-ui/button/Button'
+import useAuth from '@/hooks/useAuth'
+import { useParams } from 'react-router-dom'
+
+type HandleFunction = {
+  handelEditMode: () => void
+  handleSubmit: () => void
+  handelDeleteComment: () => void
+}
+export const CommentEditButton = ({
+  isReadOnly,
+  handleFunction
+}: {
+  isReadOnly: boolean
+  handleFunction: HandleFunction
+}) => {
+  const { handelEditMode, handleSubmit, handelDeleteComment } = handleFunction
+  const paramsData = useParams()
+  const { user: currentUser } = useAuth()
+
+  if (paramsData.userId !== currentUser?.userId) {
+    return null
+  }
+
+  return (
+    <>
+      {!isReadOnly ? (
+        <div>
+          <Button
+            color="transparent"
+            size="small"
+            fontSize="12px"
+            onClick={handelEditMode}>
+            취소
+          </Button>
+          <Button
+            size="small"
+            fontSize="12px"
+            onClick={handleSubmit}>
+            수정 완료
+          </Button>
+        </div>
+      ) : (
+        <div>
+          <Button
+            color="transparent"
+            size="small"
+            fontSize="12px"
+            onClick={handelEditMode}>
+            수정
+          </Button>
+          <Button
+            color="transparent"
+            size="small"
+            fontSize="12px"
+            onClick={handelDeleteComment}>
+            삭제
+          </Button>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/comment-detail/ReviewComment.tsx
+++ b/src/components/comment-detail/ReviewComment.tsx
@@ -1,9 +1,12 @@
 import StarRating from '../common-ui/star-rating/StarRating'
 import * as S from './CommentDetail.styled'
 import { Button } from '../common-ui/button/Button'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Input } from '../common-ui/input/Input'
 import { Comment } from '@/types/commentDetail'
+import { useCommentDelete } from '@/hooks/mutations/useCommentDelete'
+import { useCommentEdit } from '@/hooks/mutations/useCommentEdit'
+import { toastError } from '@/utils/toast'
 
 export const ReviewComment = ({
   commentData
@@ -11,9 +14,46 @@ export const ReviewComment = ({
   commentData: Comment | undefined
 }) => {
   const [isReadOnly, setIsReadOnly] = useState(true)
+  const commentRef = useRef<HTMLInputElement>(null)
+  const [commentValue, setCommentValue] = useState(commentData?.comment || '')
+
+  const { updateCommentMutation } = useCommentEdit({
+    comment_id: commentData?.comment_id || '',
+    newComment: commentRef.current?.value || ''
+  })
+  const { deleteCommentMutation } = useCommentDelete(
+    commentData?.comment_id || ''
+  )
+
+  const handelDeleteComment = () => {
+    if (window.confirm('선택한 댓글을을 삭제하시겠습니까?')) {
+      deleteCommentMutation()
+    }
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (commentRef.current) {
+      setCommentValue(e.target.value)
+      commentRef.current.value = e.target.value
+    }
+  }
 
   const handelEditMode = () => {
     setIsReadOnly(!isReadOnly)
+    if (!isReadOnly) {
+      if (commentRef.current?.value === '') {
+        setCommentValue(commentData?.comment || '')
+      }
+    }
+  }
+  const handleSubmit = () => {
+    if (commentRef.current?.value === '') {
+      toastError('댓글을 입력해주세요.')
+      return
+    } else {
+      updateCommentMutation()
+      setIsReadOnly(!isReadOnly)
+    }
   }
 
   if (!commentData) {
@@ -42,7 +82,7 @@ export const ReviewComment = ({
             <Button
               size="small"
               fontSize="12px"
-              onClick={handelEditMode}>
+              onClick={handleSubmit}>
               수정 완료
             </Button>
           </div>
@@ -58,7 +98,8 @@ export const ReviewComment = ({
             <Button
               color="transparent"
               size="small"
-              fontSize="12px">
+              fontSize="12px"
+              onClick={handelDeleteComment}>
               삭제
             </Button>
           </div>
@@ -68,8 +109,10 @@ export const ReviewComment = ({
         <p>평가</p>
         <Input
           readOnly={isReadOnly}
-          value={commentData.comment || ''}
+          value={commentValue}
           type="textarea"
+          ref={commentRef}
+          onChange={handleChange}
         />
       </S.CommentSection>
     </S.ReviewCommentContainer>

--- a/src/components/comment-detail/ReviewComment.tsx
+++ b/src/components/comment-detail/ReviewComment.tsx
@@ -1,12 +1,12 @@
 import StarRating from '../common-ui/star-rating/StarRating'
 import * as S from './CommentDetail.styled'
-import { Button } from '../common-ui/button/Button'
 import { useRef, useState } from 'react'
 import { Input } from '../common-ui/input/Input'
 import { Comment } from '@/types/commentDetail'
 import { useCommentDelete } from '@/hooks/mutations/useCommentDelete'
 import { useCommentEdit } from '@/hooks/mutations/useCommentEdit'
 import { toastError } from '@/utils/toast'
+import { CommentEditButton } from './CommentEditButton'
 
 export const ReviewComment = ({
   commentData
@@ -25,16 +25,16 @@ export const ReviewComment = ({
     commentData?.comment_id || ''
   )
 
-  const handelDeleteComment = () => {
-    if (window.confirm('선택한 댓글을을 삭제하시겠습니까?')) {
-      deleteCommentMutation()
-    }
-  }
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (commentRef.current) {
       setCommentValue(e.target.value)
       commentRef.current.value = e.target.value
+    }
+  }
+
+  const handelDeleteComment = () => {
+    if (window.confirm('선택한 댓글을을 삭제하시겠습니까?')) {
+      deleteCommentMutation()
     }
   }
 
@@ -56,9 +56,16 @@ export const ReviewComment = ({
     }
   }
 
+  const handleFunction = {
+    handelEditMode,
+    handleSubmit,
+    handelDeleteComment
+  }
+
   if (!commentData) {
     return <p>데이터가 없습니다.</p>
   }
+
   return (
     <S.ReviewCommentContainer>
       <S.RatingSection>
@@ -70,40 +77,10 @@ export const ReviewComment = ({
             isReadOnly={isReadOnly}
           />
         </div>
-        {!isReadOnly ? (
-          <div>
-            <Button
-              color="transparent"
-              size="small"
-              fontSize="12px"
-              onClick={handelEditMode}>
-              취소
-            </Button>
-            <Button
-              size="small"
-              fontSize="12px"
-              onClick={handleSubmit}>
-              수정 완료
-            </Button>
-          </div>
-        ) : (
-          <div>
-            <Button
-              color="transparent"
-              size="small"
-              fontSize="12px"
-              onClick={handelEditMode}>
-              수정
-            </Button>
-            <Button
-              color="transparent"
-              size="small"
-              fontSize="12px"
-              onClick={handelDeleteComment}>
-              삭제
-            </Button>
-          </div>
-        )}
+        <CommentEditButton
+          isReadOnly={isReadOnly}
+          handleFunction={handleFunction}
+        />
       </S.RatingSection>
       <S.CommentSection readonly={isReadOnly}>
         <p>평가</p>

--- a/src/hooks/mutations/useCommentDelete.ts
+++ b/src/hooks/mutations/useCommentDelete.ts
@@ -1,15 +1,27 @@
 import { deleteComment } from '@/service/comments/deleteDetailsComment'
+import { toastError, toastSuccess } from '@/utils/toast'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { To, useMatch, useNavigate } from 'react-router-dom'
 
 export const useCommentDelete = (comment_id: string) => {
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const isTargetPage = useMatch('/comments/detail/:type/:mediaId/:userId')
 
   const { mutate: deleteCommentMutation } = useMutation({
     mutationFn: () => deleteComment(comment_id),
     onSuccess: () => {
+      toastSuccess('해당 댓글이 삭제되었습니다.')
       queryClient.invalidateQueries({
         queryKey: ['userComment']
       })
+      if (isTargetPage) {
+        navigate(-1 as To, { state: { showToast: true } })
+      }
+    },
+    onError: (error: Error) => {
+      console.error('삭제 실패:', error)
+      toastError('댓글 삭제 중 오류가 발생했습니다.')
     }
   })
   return { deleteCommentMutation }

--- a/src/hooks/mutations/useCommentEdit.ts
+++ b/src/hooks/mutations/useCommentEdit.ts
@@ -1,4 +1,5 @@
 import { UpdateComment } from '@/service/comments/putDetailsComment'
+import { toastError, toastSuccess } from '@/utils/toast'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 type TEditComment = {
@@ -9,12 +10,18 @@ type TEditComment = {
 export const useCommentEdit = ({ comment_id, newComment }: TEditComment) => {
   const queryClient = useQueryClient()
   const updatedAt = new Date().toISOString()
+
   const { mutate: updateCommentMutation } = useMutation({
     mutationFn: () => UpdateComment(comment_id, newComment, updatedAt),
     onSuccess: () => {
+      toastSuccess('댓글이 수정되었습니다.')
       queryClient.invalidateQueries({
         queryKey: ['userComment']
       })
+    },
+    onError: (error: Error) => {
+      console.error('수정 실패:', error)
+      toastError('댓글 수정 중 오류가 발생했습니다.')
     }
   })
 

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,21 @@
+import toast from 'react-hot-toast'
+
+const toastSuccess = (message: string) => {
+  toast.success(message, {
+    duration: 1500,
+    style: {
+      fontSize: 'var(--font-small)'
+    }
+  })
+}
+
+const toastError = (message: string) => {
+  toast.error(message, {
+    duration: 1500,
+    style: {
+      fontSize: 'var(--font-small)'
+    }
+  })
+}
+
+export { toastSuccess, toastError }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

댓글 수정 및 삭제 훅을 댓글 상세 페이지에 적용했어요!
수정 삭제 훅에 토스트 적용 및 댓글 상세 페이지에서 삭제 시 이전 페이지로 이동하도록 했어요!
현재 로그인 한 유저가 댓글 작성자일 경우 수정 및 삭제 기능을 활용할 수 있도록 조건부 렌더링을 했어요!

## 📋 작업 내용

- 댓글 수정 및 삭제 hook 댓글 상세 페이지 적용
- toast utill 함수 생성
- 댓글 상세 페이지 내부 버튼 컴포넌트 분리

## 📸 스크린샷 (선택 사항)

![스크린샷 2025-01-24 174513](https://github.com/user-attachments/assets/3d68cda9-bb8b-4a9b-acdb-5f0948d2cfa7)

![스크린샷 2025-01-24 174439](https://github.com/user-attachments/assets/4a996afb-8303-480e-9013-28fbdd7d7ca7)

![스크린샷 2025-01-24 162210](https://github.com/user-attachments/assets/02bffc8f-09aa-4300-a861-6a18b7698b93)

![스크린샷 2025-01-24 162014](https://github.com/user-attachments/assets/80b3fbc2-45e6-411b-9f15-28e4d0ed87fb)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
