### PR TITLE
[✨ Feature] 댓글 상세 페이지 시리즈 부분 추가 및 별점 수정 기능 추가

### DIFF
--- a/src/components/comment-detail/ReviewComment.tsx
+++ b/src/components/comment-detail/ReviewComment.tsx
@@ -7,6 +7,7 @@ import { useCommentDelete } from '@/hooks/mutations/useCommentDelete'
 import { useCommentEdit } from '@/hooks/mutations/useCommentEdit'
 import { CommentEditButton } from './CommentEditButton'
 import toast from 'react-hot-toast'
+import { useRating } from '@/hooks/useRating'
 
 export const ReviewComment = ({
   commentData
@@ -16,10 +17,12 @@ export const ReviewComment = ({
   const [isReadOnly, setIsReadOnly] = useState(true)
   const commentRef = useRef<HTMLInputElement>(null)
   const [commentValue, setCommentValue] = useState(commentData?.comment || '')
+  const { rating } = useRating()
 
   const { updateCommentMutation } = useCommentEdit({
     comment_id: commentData?.comment_id || '',
-    newComment: commentRef.current?.value || ''
+    newComment: commentRef.current?.value || '',
+    rating: rating
   })
   const { deleteCommentMutation } = useCommentDelete(
     commentData?.comment_id || ''
@@ -73,7 +76,7 @@ export const ReviewComment = ({
           <p>평점</p>
           <StarRating
             size={30}
-            initialRating={commentData.rating || 0}
+            CommentRating={commentData.rating || 0}
             isReadOnly={isReadOnly}
           />
         </div>

--- a/src/components/comment-detail/ReviewComment.tsx
+++ b/src/components/comment-detail/ReviewComment.tsx
@@ -8,24 +8,28 @@ import { useCommentEdit } from '@/hooks/mutations/useCommentEdit'
 import { CommentEditButton } from './CommentEditButton'
 import toast from 'react-hot-toast'
 import { useRating } from '@/hooks/useRating'
+import { useParams } from 'react-router-dom'
 
 export const ReviewComment = ({
   commentData
 }: {
   commentData: Comment | undefined
 }) => {
+  const paramsData = useParams()
   const [isReadOnly, setIsReadOnly] = useState(true)
   const commentRef = useRef<HTMLInputElement>(null)
   const [commentValue, setCommentValue] = useState(commentData?.comment || '')
-  const { rating } = useRating()
+  const { rating, setRating } = useRating()
 
   const { updateCommentMutation } = useCommentEdit({
+    types: paramsData.type as 'movie' | 'tv',
     comment_id: commentData?.comment_id || '',
     newComment: commentRef.current?.value || '',
     rating: rating
   })
   const { deleteCommentMutation } = useCommentDelete(
-    commentData?.comment_id || ''
+    commentData?.comment_id || '',
+    paramsData.type as 'movie' | 'tv'
   )
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -43,6 +47,7 @@ export const ReviewComment = ({
 
   const handelEditMode = () => {
     setIsReadOnly(!isReadOnly)
+    setRating(commentData?.rating || 0)
     if (!isReadOnly) {
       if (commentRef.current?.value === '') {
         setCommentValue(commentData?.comment || '')

--- a/src/components/movie-details-comment/commentEdit.tsx
+++ b/src/components/movie-details-comment/commentEdit.tsx
@@ -1,5 +1,6 @@
 import { useCommentEdit } from '@/hooks/mutations/useCommentEdit'
 import { useState } from 'react'
+import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 
 type CommentEditProps = {
@@ -64,9 +65,11 @@ const CancelButton = styled.button`
 `
 
 function CommentEdit({ comment_id, setModifier, comment }: CommentEditProps) {
+  const paramsData = useParams()
   const [newComment, setNewComment] = useState(comment)
 
   const { updateCommentMutation } = useCommentEdit({
+    types: paramsData.type as 'movie' | 'tv',
     comment_id,
     newComment
   })

--- a/src/components/movie-details-comment/commentList.tsx
+++ b/src/components/movie-details-comment/commentList.tsx
@@ -10,6 +10,7 @@ import CommentEdit from './commentEdit'
 import { useCommentDelete } from '@/hooks/mutations/useCommentDelete'
 import useAuth from '@/hooks/useAuth'
 import StarRating from '../common-ui/star-rating/StarRating'
+import { useParams } from 'react-router-dom'
 
 type TComment = {
   key: string
@@ -36,6 +37,7 @@ export default function CommentList({
   comment_id,
   rating
 }: TComment) {
+  const paramsData = useParams()
   const [modifier, setModifier] = useState(false)
   const { user } = useAuth()
 
@@ -45,7 +47,10 @@ export default function CommentList({
   })
 
   //댓글삭제
-  const { deleteCommentMutation } = useCommentDelete(comment_id)
+  const { deleteCommentMutation } = useCommentDelete(
+    comment_id,
+    paramsData.type as 'movie' | 'tv'
+  )
 
   function handleDelete() {
     deleteCommentMutation()

--- a/src/hooks/mutations/useCommentDelete.ts
+++ b/src/hooks/mutations/useCommentDelete.ts
@@ -3,13 +3,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 import { To, useMatch, useNavigate } from 'react-router-dom'
 
-export const useCommentDelete = (comment_id: string) => {
+export const useCommentDelete = (comment_id: string, types: 'movie' | 'tv') => {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
   const isTargetPage = useMatch('/comments/detail/:type/:mediaId/:userId')
 
   const { mutate: deleteCommentMutation } = useMutation({
-    mutationFn: () => deleteComment(comment_id),
+    mutationFn: () => deleteComment(comment_id, types),
     onSuccess: () => {
       toast.success('해당 댓글이 삭제되었습니다.')
       queryClient.invalidateQueries({

--- a/src/hooks/mutations/useCommentEdit.ts
+++ b/src/hooks/mutations/useCommentEdit.ts
@@ -3,12 +3,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import toast from 'react-hot-toast'
 
 type TEditComment = {
+  types: 'movie' | 'tv'
   comment_id: string
   newComment: string
   rating?: number
 }
 
 export const useCommentEdit = ({
+  types,
   comment_id,
   newComment,
   rating
@@ -17,7 +19,8 @@ export const useCommentEdit = ({
   const updatedAt = new Date().toISOString()
 
   const { mutate: updateCommentMutation } = useMutation({
-    mutationFn: () => UpdateComment(comment_id, newComment, updatedAt, rating),
+    mutationFn: () =>
+      UpdateComment(types, comment_id, newComment, updatedAt, rating),
     onSuccess: () => {
       toast.success('댓글이 수정되었습니다.')
       queryClient.invalidateQueries({

--- a/src/hooks/queries/useFetchComment.ts
+++ b/src/hooks/queries/useFetchComment.ts
@@ -3,15 +3,17 @@ import { Comment } from '@/types/commentDetail'
 import { useQuery } from '@tanstack/react-query'
 
 const useFetchComment = ({
+  types,
   userId,
   mediaId
 }: {
+  types: 'movie' | 'tv'
   userId: string
   mediaId: string
 }) => {
   return useQuery<Comment, Error, Comment, string[]>({
     queryKey: ['comments', userId, mediaId],
-    queryFn: () => fetchComments({ userId, mediaId }),
+    queryFn: () => fetchComments({ userId, mediaId, types }),
     enabled: !!userId && !!mediaId,
     staleTime: 1000 * 60 * 5,
     throwOnError: true

--- a/src/pages/CommentDetail.tsx
+++ b/src/pages/CommentDetail.tsx
@@ -16,6 +16,7 @@ export const CommentDetailPage = () => {
   )
 
   const { data: commentData, isLoading } = useFetchComment({
+    types: paramsData.type as 'movie' | 'tv',
     userId: paramsData.userId as string,
     mediaId: paramsData.mediaId as string
   })

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -97,7 +97,11 @@ const router = createBrowserRouter([
       },
       {
         path: '/comments/detail/:type/:mediaId/:userId',
-        element: <CommentDetailPage />
+        element: (
+          <RatingProvider>
+            <CommentDetailPage />
+          </RatingProvider>
+        )
       },
       {
         path: '/signup',

--- a/src/service/comments/deleteDetailsComment.ts
+++ b/src/service/comments/deleteDetailsComment.ts
@@ -1,8 +1,8 @@
 import { supabase } from '../../../supabaseConfig'
 
-export async function deleteComment(comment_id: string) {
+export async function deleteComment(comment_id: string, types: 'movie' | 'tv') {
   const { error } = await supabase
-    .from('comments')
+    .from(types === 'movie' ? 'comments' : 'drama_comments')
     .delete()
     .eq('comment_id', comment_id)
 

--- a/src/service/comments/fetchComment.ts
+++ b/src/service/comments/fetchComment.ts
@@ -2,17 +2,19 @@ import { Comment } from '@/types/commentDetail'
 import { supabase } from '../../../supabaseConfig'
 
 export const fetchComments = async ({
+  types,
   userId,
   mediaId
 }: {
+  types: 'movie' | 'tv'
   userId: string
   mediaId: string
 }): Promise<Comment> => {
   const { data, error } = await supabase
-    .from('comments')
+    .from(types === 'movie' ? 'comments' : 'drama_comments')
     .select('*')
     .eq('user_id', userId)
-    .eq('movie_id', mediaId)
+    .eq(types === 'movie' ? 'movie_id' : 'drama_id', mediaId)
     .single()
 
   if (error) {

--- a/src/service/comments/putDetailsComment.ts
+++ b/src/service/comments/putDetailsComment.ts
@@ -1,13 +1,14 @@
 import { supabase } from '../../../supabaseConfig'
 
 export async function UpdateComment(
+  types: 'movie' | 'tv',
   comment_id: string,
   newComment: string,
   updatedAt: string,
   rating?: number
 ) {
   const { data, error } = await supabase
-    .from('comments')
+    .from(types === 'movie' ? 'comments' : 'drama_comments')
     .update({ comment: newComment, updated_at: updatedAt, rating: rating })
     .eq('comment_id', comment_id)
     .select()


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

댓글 상세 페이지에서 시리즈에 대한 댓글을 보기 위해 시리즈 부분에 대한 fetch 및 별점 수정 기능을 추가했습니다.

## 📋 작업 내용

- 댓글 상세 페이지 별점 수정 기능 추가
- 시리즈 댓글일 경우 조회, 수정, 삭제 기능을 drama_comments  테이블로 접근하도록 수정
- 해당 기능 수정으로 인해 commentList, commentEdit 파일에 임의로 useParams 사용 및 types 지정(해당 부분 담당자 확인 필요)

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/8d0745b8-5a84-48d8-bb3f-51fef46550cb)

## 📄 기타

별점 수정 기능을 추가 했습니다.
댓글 상세 페이지에서 시리즈 댓글 일 경우 조회, 수정, 삭제를 drama_comments 테이블로 접근하도록 수정했습니다.
기능 관련 query 및 mutation 로직을 수정하여 해당 로직을 사용하는 commentList, commentEdit 파일에 임의로 useParams 사용 및 types 지정했습니다. 이 부분은 해당 PR 혹은 merge 이후 발견되는 문제점을 수정해야 합니다.
